### PR TITLE
Any interest in having asset_hash work with Rails 2.3.11?

### DIFF
--- a/lib/asset_hash.rb
+++ b/lib/asset_hash.rb
@@ -1,7 +1,7 @@
 require 'digest/md5'
 require 'time'
 require 'mime/types'
-require 'asset_hash/railtie' if defined?(Rails)
+require 'asset_hash/railtie' if defined?(Rails::Railtie)
 
 module AssetHash
   def self.process!

--- a/lib/asset_hash/railtie.rb
+++ b/lib/asset_hash/railtie.rb
@@ -1,12 +1,9 @@
 require 'asset_hash'
-begin
-  require 'rails'
-  module AssetHash
-    class Railtie < Rails::Railtie
-      rake_tasks do
-        load "tasks/asset_hash.rake"
-      end
+require 'rails'
+module AssetHash
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load "tasks/asset_hash.rake"
     end
   end
-rescue LoadError
 end

--- a/lib/asset_hash/railtie.rb
+++ b/lib/asset_hash/railtie.rb
@@ -1,9 +1,12 @@
 require 'asset_hash'
-require 'rails'
-module AssetHash
-  class Railtie < Rails::Railtie
-    rake_tasks do
-      load "tasks/asset_hash.rake"
+begin
+  require 'rails'
+  module AssetHash
+    class Railtie < Rails::Railtie
+      rake_tasks do
+        load "tasks/asset_hash.rake"
+      end
     end
   end
+rescue LoadError
 end


### PR DESCRIPTION
Here is my set up... https://gist.github.com/991732 Rails 2.3.11 doesn't have a `ActionController::Base.asset_path=` setting... Had to monkey patch Rail's AssetTagHelper... But in any case, the `require 'asset_hash/railtie' if defined?(Rails)` line is making it so that I can't use asset_hash at all with Rails 2.3.11...
